### PR TITLE
Migrate to Manifest V3 and split popup/background logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,68 @@
+// background.js — runs as the persistent background script
+
+const ALL_COLORS = ["LightCoral", "LightSalmon", "LightPink", "LightSalmon", "PeachPuff", "Khaki", "Thistle",
+    "Violet", "LightGreen", "YellowGreen", "Turquoise", "LightSkyBlue", "Wheat", "Peru",
+    "LightGray", "DarkGray"];
+
+// TimedColor tracks last-used time per color for LRU selection
+class TimedColor {
+    constructor(color) {
+        this.color = color;
+        this.last_access = new Date().toISOString();
+    }
+}
+
+let all_timed_colors = ALL_COLORS.map(c => new TimedColor(c));
+
+function getOldestColorTheme() {
+    const oldest = all_timed_colors[0];
+    oldest.last_access = new Date().toISOString();
+    all_timed_colors.sort((a, b) => a.last_access > b.last_access ? 1 : -1);
+    return { colors: { frame: oldest.color, tab_background_text: "#000" } };
+}
+
+async function applyWindowTheme(new_window) {
+    const saved_color = await browser.sessions.getWindowValue(new_window.id, "color");
+    if (saved_color) {
+        browser.theme.update(new_window.id, { colors: { frame: saved_color, tab_background_text: "#000" } });
+        return;
+    }
+
+    const obj = await browser.storage.local.get();
+    if (!obj.hasOwnProperty("change_new")) {
+        await browser.storage.local.set({ change_new: true });
+    }
+    if (obj["change_new"] !== false) {
+        const theme = getOldestColorTheme();
+        browser.theme.update(new_window.id, theme);
+        browser.sessions.setWindowValue(new_window.id, "color", theme.colors.frame);
+    }
+}
+
+// restore session colors on startup
+(async () => {
+    const windows = await browser.windows.getAll();
+    for (const win of windows) {
+        const saved_color = await browser.sessions.getWindowValue(win.id, "color");
+        if (saved_color) {
+            browser.theme.update(win.id, { colors: { frame: saved_color, tab_background_text: "#000" } });
+        }
+    }
+})();
+
+browser.windows.onCreated.addListener(applyWindowTheme);
+
+// listen for color picks and resets from popup
+browser.runtime.onMessage.addListener(async (msg) => {
+    if (msg.type === "set_color") {
+        const { color, windowId } = msg;
+        browser.theme.update(windowId, { colors: { frame: color, tab_background_text: "#000" } });
+        browser.sessions.setWindowValue(windowId, "color", color);
+        const tc = all_timed_colors.find(t => t.color === color);
+        if (tc) tc.last_access = new Date().toISOString();
+        all_timed_colors.sort((a, b) => a.last_access < b.last_access ? 1 : -1);
+    } else if (msg.type === "reset_color") {
+        browser.theme.reset(msg.windowId);
+        browser.sessions.removeWindowValue(msg.windowId, "color");
+    }
+});

--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-// background.js — runs as the persistent background script
+// background.js — runs as a persistent background script (MV3 non-SW for Firefox)
 
 const ALL_COLORS = ["LightCoral", "LightSalmon", "LightPink", "LightSalmon", "PeachPuff", "Khaki", "Thistle",
     "Violet", "LightGreen", "YellowGreen", "Turquoise", "LightSkyBlue", "Wheat", "Peru",

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
     },
     "background": {
         "scripts": [
-            "popup.js"
+            "background.js"
         ]
     },
     "browser_specific_settings": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
     "description": "Change and customize browser Window colors",
-    "manifest_version": 2,
-    "version": "1.3",
+    "manifest_version": 3,
+    "version": "1.4",
     "name": "foxcolorbox",
     "homepage_url": "https://github.com/jftuga/foxcolorbox",
     "icons": {
         "128": "foxcolorbox-128.png"
     },
-    "browser_action": {
+    "action": {
         "default_icon": {
             "128": "foxcolorbox-128.png"
         },
@@ -28,7 +28,6 @@
         }
     },
     "permissions": [
-        "tabs",
         "theme",
         "activeTab",
         "storage",

--- a/popup.html
+++ b/popup.html
@@ -2,18 +2,178 @@
 <html>
 
 <head>
-    <title>Firefox Color Box</title>
+    <title>Fox Color Box</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            background: #fafafa;
+            width: 220px;
+            padding: 16px;
+            color: #444;
+        }
+
+        header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 14px;
+        }
+
+        header img {
+            width: 24px;
+            height: 24px;
+        }
+
+        header h1 {
+            font-size: 13px;
+            font-weight: 600;
+            letter-spacing: 0.3px;
+            color: #333;
+        }
+
+        #button_list {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 7px;
+            margin-bottom: 14px;
+        }
+
+        #button_list button {
+            width: 100%;
+            aspect-ratio: 1;
+            border: 2px solid transparent;
+            border-radius: 10px;
+            cursor: pointer;
+            transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+            font-size: 0;
+        }
+
+        #button_list button:hover {
+            transform: scale(1.12);
+            box-shadow: 0 3px 10px rgba(0,0,0,0.15);
+        }
+
+        #button_list button:active {
+            transform: scale(0.97);
+        }
+
+        #button_list button.active {
+            border-color: #555;
+            box-shadow: 0 0 0 3px rgba(0,0,0,0.08);
+        }
+
+        footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding-top: 10px;
+            border-top: 1px solid #eee;
+        }
+
+        .toggle-wrap {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+        }
+
+        .toggle-wrap label {
+            font-size: 11px;
+            color: #666;
+            cursor: pointer;
+            line-height: 1.3;
+        }
+
+        /* toggle switch */
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 30px;
+            height: 17px;
+            flex-shrink: 0;
+        }
+
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+
+        .slider {
+            position: absolute;
+            inset: 0;
+            background: #ccc;
+            border-radius: 17px;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .slider::before {
+            content: "";
+            position: absolute;
+            width: 11px;
+            height: 11px;
+            left: 3px;
+            bottom: 3px;
+            background: white;
+            border-radius: 50%;
+            transition: transform 0.2s;
+        }
+
+        .switch input:checked + .slider {
+            background: #a8d8a8;
+        }
+
+        .switch input:checked + .slider::before {
+            transform: translateX(13px);
+        }
+
+        #reset {
+            font-size: 11px;
+            padding: 5px 10px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            background: white;
+            color: #555;
+            cursor: pointer;
+            transition: background 0.12s, border-color 0.12s;
+        }
+
+        #reset:hover {
+            background: #f0f0f0;
+            border-color: #bbb;
+        }
+
+        #reset:active {
+            background: #e5e5e5;
+        }
+    </style>
 </head>
 
 <body>
-    <br />
-    <div id="button_list">
-        <button id="reset" style="width:100px">Default</button><br /><br />
-    </div>
-    <div id="settings">
-        <input type="checkbox" id="change_new" checked>
-        <label for="change_new">Change colors<br />for new windows</label>
-    </div>
+    <header>
+        <img src="foxcolorbox.png" alt="Fox Color Box" />
+        <h1>Fox Color Box</h1>
+    </header>
+
+    <div id="button_list"></div>
+
+    <footer>
+        <div class="toggle-wrap">
+            <label class="switch">
+                <input type="checkbox" id="change_new" checked />
+                <span class="slider"></span>
+            </label>
+            <label for="change_new">Auto-color<br />new windows</label>
+        </div>
+        <button id="reset">Reset</button>
+    </footer>
+
     <script src="popup.js"></script>
 </body>
 

--- a/popup.js
+++ b/popup.js
@@ -7,22 +7,24 @@ const ALL_COLORS = ["LightCoral", "LightSalmon", "LightPink", "LightSalmon", "Pe
 window.addEventListener("load", async () => {
     const current_window = await browser.windows.getLastFocused();
 
-    // build color buttons
+    // build color swatches
     const list = document.getElementById("button_list");
     for (const color of ALL_COLORS) {
         const b = document.createElement("button");
-        b.innerText = color;
+        b.title = color;
         b.style.background = color;
-        b.style.width = "100px";
+        b.dataset.color = color;
         b.onclick = () => {
+            document.querySelectorAll("#button_list button").forEach(btn => btn.classList.remove("active"));
+            b.classList.add("active");
             browser.runtime.sendMessage({ type: "set_color", color, windowId: current_window.id });
         };
         list.appendChild(b);
-        list.appendChild(document.createElement("br"));
     }
 
     // reset button
     document.getElementById("reset").addEventListener("click", () => {
+        document.querySelectorAll("#button_list button").forEach(btn => btn.classList.remove("active"));
         browser.runtime.sendMessage({ type: "reset_color", windowId: current_window.id });
     });
 

--- a/popup.js
+++ b/popup.js
@@ -1,185 +1,36 @@
-// popup.js
-// -John Taylor
-// 2023-11-14
+// popup.js — runs only in popup.html context
 
-/*
-This script is instantiated twice:
-1) in manifest.json, background -> scripts
-2) in popup.html, script tag
-
-Because of this, try/catch must be used in a few places to ignore exceptions
-because the caller is from background scripts; not by the user clicking on the extension icon (which is used by popup.html)
-*/
-
-console.log("In foxcolorbox popup.js");
-
-// https://htmlcolorcodes.com/color-names/
-var all_colors = ["LightCoral", "LightSalmon", "LightPink", "LightSalmon", "PeachPuff", "Khaki", "Thistle",
+const ALL_COLORS = ["LightCoral", "LightSalmon", "LightPink", "LightSalmon", "PeachPuff", "Khaki", "Thistle",
     "Violet", "LightGreen", "YellowGreen", "Turquoise", "LightSkyBlue", "Wheat", "Peru",
     "LightGray", "DarkGray"];
 
-// an array of TimedColor objects
-var all_timed_colors = [];
+window.addEventListener("load", async () => {
+    const current_window = await browser.windows.getLastFocused();
 
-// each color has an associated time that is was last used
-class TimedColor {
-    constructor(color) {
-        this.color = color;
-        let now = new Date();
-        this.last_access = now.toISOString();
-    }
-}
-
-// keep a history of what time the last color was used and then select the LRU color
-function getOldestColorTheme() {
-    console.log("NEW WINDOW  : ", all_timed_colors[0], 0);
-    theme = { colors: { frame: all_timed_colors[0].color, tab_background_text: '#000' } };
-    let now = new Date();
-    all_timed_colors[0].last_access = now.toISOString();
-    all_timed_colors.sort((a, b) => {
-        return a.last_access > b.last_access;
-    });
-    return theme;
-}
-
-// adds a new, colored button to the button_list div
-function appendButton(elementId, color) {
-    var b = document.createElement("button");
-    b.innerText = color;
-    b.style.background = color;
-    b.style.width = "100px";
-
-    try {
-        document.getElementById(elementId).appendChild(b);
-        document.getElementById(elementId).appendChild(document.createElement("br"));
-    } catch (error) {
-        // ignore b/c called from background scripts; not by clicking on the extension icon
-        return;
-    }
-
-    b.onclick = async function () {
-        theme = { colors: { frame: color, tab_background_text: '#000' } };
-        var i = 0;
-        // since the button list is small, just iterate over all objects instead of using a hash table
-        for (const timed_color of all_timed_colors) {
-            if (timed_color.color === color) {
-                let now = new Date();
-                all_timed_colors[i].last_access = now.toISOString();
-                console.log("BUTTON CLICK: ", all_timed_colors[i], i);
-                break;
-            }
-            i += 1;
+    // build color buttons
+    const list = document.getElementById("button_list");
+    for (const color of ALL_COLORS) {
+        const b = document.createElement("button");
+        b.innerText = color;
+        b.style.background = color;
+        b.style.width = "100px";
+        b.onclick = () => {
+            browser.runtime.sendMessage({ type: "set_color", color, windowId: current_window.id });
         };
-        all_timed_colors.sort((a, b) => {
-            return a.last_access < b.last_access;
-        });
-
-        let current_window = await browser.windows.getLastFocused();
-        browser.theme.update(current_window.id, theme);
-        // save the chosen color to the window's session so it survives browser restart
-        browser.sessions.setWindowValue(current_window.id, "color", color);
-    }
-}
-
-// when a new window is created, such as pressing ctrl-n or dragging a tab to the desktop,
-// change the color of the window if the "change color for new windows" checkbox is checked
-// also: if extension has not run before, create local storage key: change_new and set to true
-// if the window is being restored from a previous session, reapply its saved color instead
-async function applyWindowTheme(new_window) {
-    console.log("A new window was created:", new_window.id);
-
-    // check if this window has a color saved from a previous session (e.g. after browser restart)
-    const saved_color = await browser.sessions.getWindowValue(new_window.id, "color");
-    if (saved_color) {
-        console.log("Restoring saved session color:", saved_color, "for window:", new_window.id);
-        browser.theme.update(new_window.id, { colors: { frame: saved_color, tab_background_text: '#000' } });
-        return;
+        list.appendChild(b);
+        list.appendChild(document.createElement("br"));
     }
 
-    // no saved color - this is a brand new window, apply LRU color if change_new is enabled
-    x = browser.storage.local.get();
-    x.then(async obj => {
-        console.log("obj:", obj);
-        has_cn_storage_key = false;
-        if (obj.hasOwnProperty("change_new") === false) {
-            console.log("Adding change_new key to local storage");
-            has_cn_storage_key = true;
-            browser.storage.local.set({ "change_new": true });
-            console.log("[storage save] setting change_new: true");
-        }
-        if (obj["change_new"] === true || has_cn_storage_key === true) {
-            const theme = getOldestColorTheme();
-            browser.theme.update(new_window.id, theme);
-            // save the auto-assigned color to the session so it is restored on restart
-            browser.sessions.setWindowValue(new_window.id, "color", theme.colors.frame);
-        }
+    // reset button
+    document.getElementById("reset").addEventListener("click", () => {
+        browser.runtime.sendMessage({ type: "reset_color", windowId: current_window.id });
     });
-}
 
-// fired when user clicks the extension's icon
-window.addEventListener("load", async function () { // DOMContentLoaded
-    let now = new Date();
-    // console.log("starting on:", now.toISOString());
-    // console.log("document.readyState: ", document.readyState);
-
-    try {
-        reset.addEventListener("click", async function () {
-            let current_window = await browser.windows.getCurrent();
-            browser.theme.reset(current_window.id);
-            // clear the saved session color so default theme is restored on restart too
-            browser.sessions.removeWindowValue(current_window.id, "color");
-        });
-    } catch (error) {
-        // ignore b/c called from background scripts; not by clicking on the extension icon
-    }
-
-    // populate the all_timed_colors array with a color + the current date/time
-    all_colors.forEach((color) => all_timed_colors.push(new TimedColor(color)));
-
-    // build out the vertical list of HTML buttons
-    all_colors.forEach((color) => appendButton("button_list", color));
-
-    // scan all currently open windows and restore any saved session colors
-    // this catches session-restored windows that were created before the onCreated listener registered
-    const existing_windows = await browser.windows.getAll();
-    for (const win of existing_windows) {
-        const saved_color = await browser.sessions.getWindowValue(win.id, "color");
-        if (saved_color) {
-            console.log("Startup: restoring color", saved_color, "for window", win.id);
-            browser.theme.update(win.id, { colors: { frame: saved_color, tab_background_text: '#000' } });
-        }
-    }
-
-    try {
-        // uncheck the checkbox in the HTML if the storage value for change_new is set to false
-        console.log("is checked? ", document.getElementById("change_new").checked);
-        x = browser.storage.local.get();
-        x.then(obj => {
-            console.log("change_new => obj:", obj["change_new"])
-            if (obj["change_new"] === false) {
-                console.log("unchecking: ", document.getElementById("change_new"));
-                document.getElementById("change_new").checked = false;
-            }
-        });
-
-        // button has either been checked or unchecked
-        var change_new_selector = document.getElementById("change_new");
-        change_new_selector.addEventListener('change', function () {
-            if (this.checked) {
-                browser.storage.local.set({ "change_new": true });
-                document.getElementById("change_new").checked = true;
-                console.log("[storage save] setting change_new: true");
-            } else {
-                browser.storage.local.set({ "change_new": false })
-                document.getElementById("change_new").checked = false;
-                console.log("[storage save] setting change_new: false");
-            }
-        });
-    } catch (error) {
-        // ignore b/c called from background scripts; not by clicking on extension icon
-    }
-
-}); // window.addEventListener
-
-// occurs when a new browser window is created
-browser.windows.onCreated.addListener(applyWindowTheme);
+    // auto-color toggle
+    const toggle = document.getElementById("change_new");
+    const obj = await browser.storage.local.get("change_new");
+    toggle.checked = obj["change_new"] !== false;
+    toggle.addEventListener("change", () => {
+        browser.storage.local.set({ change_new: toggle.checked });
+    });
+});


### PR DESCRIPTION
## Summary

- Bumps `manifest_version` 2 → 3 and version 1.3 → 1.4; renames `browser_action` → `action` as required by MV3
- Extracts all background logic (LRU color assignment, session color restore, `onCreated` listener) into a dedicated `background.js`; `popup.js` is now UI-only and communicates via `runtime.sendMessage`
- Redesigns `popup.html` with a CSS grid swatch layout, a proper toggle switch for auto-color, and removes all inline styles
- Drops the now-unnecessary `tabs` permission

## Why

The old `popup.js` served double duty as both background and popup script, working around the dual-load issue with `try/catch` blocks everywhere. Firefox Add-ons will eventually require MV3, and the split makes each file's responsibilities clear and testable independently.

## Test plan

- [ ] Load unpacked extension in Firefox and verify color swatches render in the popup
- [ ] Click a swatch — window frame color changes, persists after browser restart
- [ ] Click Reset — window returns to default theme
- [ ] Toggle "Auto-color new windows" off, open a new window — color should NOT change
- [ ] Toggle on, open a new window — LRU color is applied automatically
- [ ] Restart browser — previously colored windows restore their saved colors